### PR TITLE
Update gpio.cpp

### DIFF
--- a/src/gpio.cpp
+++ b/src/gpio.cpp
@@ -35,6 +35,7 @@ Author:    Kristjan Runarsson
 #include "gpio.h"
 
 #define DELAY(delay) usleep(delay)
+#define PGOOD_SETTLE_DELAY 500000
 
 using namespace std;
 
@@ -377,6 +378,8 @@ int gpio_read_battery_level_raw(config *conf)
         return CHARGING; 
     }
     DELAY(delay);
+    
+    // reset the comparator
 
     status = digitalWrite(pin_no_ud, HIGH);
     if(status == GPIO_ERROR) { return status; }
@@ -403,6 +406,7 @@ int gpio_read_battery_level_raw(config *conf)
     status = digitalWrite(pin_no_cs, HIGH);
     if(status == GPIO_ERROR) { return status; }
     DELAY(delay);
+    DELAY(PGOOD_SETTLE_DELAY); // force a  1/2 second delay for pgood to settle in case no battery is attached.
 
     status_pgood = digitalRead(pin_no_pgood);
     if(status_pgood == GPIO_ERROR) { return status_pgood; }
@@ -415,6 +419,8 @@ int gpio_read_battery_level_raw(config *conf)
     status = digitalWrite(pin_no_cs, LOW);
     if(status == GPIO_ERROR) { return status; }
     DELAY(delay);
+    
+    // read the level now
 
     status_pgood = digitalRead(pin_no_pgood);
     if(status_pgood == GPIO_ERROR) { return status_pgood; }


### PR DESCRIPTION
Added a forced delay to give pgood a chance to stabilize if there is no battery attached.  Without this delay a low battery shutdown can be triggered.

An alternate (maybe safer) implementation when pgood is false after a reset may be to just give up the measurement all together with some return code other than a battery measurement that may cause low battery shutdown.

My Suspicion of cause:  When no battery is attached, the battery charger sees the (high) impedance of the comparator circuit.  When resetting the comparator, the impedance can change significantly and rapidly compared to the charger's expectations, so it changes the charger may change the output voltage to compensate.  Once the impedance is stable, the charger resumes outputting 4.2V, which then returns equivalent of 100% charged.
